### PR TITLE
feat: Add Vertex AI Gemini 3.1 Pro support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,15 @@
 # Get your API key at: https://app.tavily.com/
 TAVILY_API_KEY=tvly-your_api_key_here
 
-# AWS Region for Bedrock
-AWS_REGION=us-east-1
+# Model Provider: 'bedrock' (default) or 'vertexai'
+MODEL_PROVIDER=bedrock
 
-# Bedrock Model ID (optional, defaults to Claude Sonnet 4.5)
-BEDROCK_MODEL_ID=us.anthropic.claude-sonnet-4-5-20250929-v1:0
+# --- Bedrock Configuration ---
+AWS_REGION=us-east-1
+BEDROCK_MODEL_ID=us.anthropic.claude-opus-4-6-v1
+
+# --- Vertex AI Configuration ---
+# GEMINI_MODEL_ID=gemini-3.1-pro
+# GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+# GOOGLE_CLOUD_LOCATION=us-central1
+# GOOGLE_GENAI_USE_VERTEXAI=true

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ AWS_REGION=us-east-1
 BEDROCK_MODEL_ID=us.anthropic.claude-opus-4-6-v1
 
 # --- Vertex AI Configuration ---
-# GEMINI_MODEL_ID=gemini-3.1-pro
+# GEMINI_MODEL_ID=gemini-3.1-pro-preview
 # GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 # GOOGLE_CLOUD_LOCATION=us-central1
 # GOOGLE_GENAI_USE_VERTEXAI=true

--- a/docs/vertex-ai-gemini-implementation.md
+++ b/docs/vertex-ai-gemini-implementation.md
@@ -24,7 +24,7 @@ def create_model(provider: str | None = None):
 
     if provider == "vertexai":
         from strands.models.gemini import GeminiModel
-        model_id = os.getenv("GEMINI_MODEL_ID", "gemini-3.1-pro")
+        model_id = os.getenv("GEMINI_MODEL_ID", "gemini-3.1-pro-preview")
         return GeminiModel(model_id=model_id)
     else:
         model_id = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-6-v1")
@@ -45,7 +45,7 @@ MODEL_PROVIDER=bedrock
 
 ```bash
 MODEL_PROVIDER=vertexai
-GEMINI_MODEL_ID=gemini-3.1-pro
+GEMINI_MODEL_ID=gemini-3.1-pro-preview
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 GOOGLE_CLOUD_LOCATION=us-central1
 GOOGLE_GENAI_USE_VERTEXAI=true

--- a/docs/vertex-ai-gemini-implementation.md
+++ b/docs/vertex-ai-gemini-implementation.md
@@ -1,0 +1,58 @@
+# Vertex AI Gemini 3.1 Pro 対応 実装結果
+
+## 概要
+
+Slidev AgentにVertex AI Gemini 3.1 Proのサポートを追加しました。環境変数`MODEL_PROVIDER`でBedrock/Vertex AIの切り替えが可能です。
+
+## 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `pyproject.toml` | `strands-agents[gemini]`に変更、description更新 |
+| `src/slidev_agent/agent.py` | `create_model()`関数追加、`create_slidev_agent()`をリファクタリング |
+| `src/slidev_agent/runtime.py` | `create_model()`をインポートして使用、BedrockModel直接インポートを削除 |
+| `.env.example` | Vertex AI関連の環境変数テンプレート追加 |
+| `uv.lock` | gemini依存パッケージ追加（google-genai, google-auth等） |
+
+## 主な変更点
+
+### `create_model()` 関数（`agent.py`）
+
+```python
+def create_model(provider: str | None = None):
+    provider = provider or os.getenv("MODEL_PROVIDER", "bedrock")
+
+    if provider == "vertexai":
+        from strands.models.gemini import GeminiModel
+        model_id = os.getenv("GEMINI_MODEL_ID", "gemini-3.1-pro")
+        return GeminiModel(model_id=model_id)
+    else:
+        model_id = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-6-v1")
+        region = os.getenv("AWS_REGION", "us-east-1")
+        return BedrockModel(model_id=model_id, region_name=region)
+```
+
+### 使い方
+
+#### Bedrock（デフォルト）
+
+```bash
+# .envに設定不要（デフォルトでBedrock）
+MODEL_PROVIDER=bedrock
+```
+
+#### Vertex AI Gemini
+
+```bash
+MODEL_PROVIDER=vertexai
+GEMINI_MODEL_ID=gemini-3.1-pro
+GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+GOOGLE_CLOUD_LOCATION=us-central1
+GOOGLE_GENAI_USE_VERTEXAI=true
+```
+
+## 検証結果
+
+- `uv lock` ... 成功（google-genai, google-auth等8パッケージ追加）
+- `uv run --extra dev pytest` ... 10テスト全てパス
+- 後方互換性 ... `MODEL_PROVIDER`未設定時はデフォルトでBedrock動作

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "slidev-agent"
 version = "0.1.0"
-description = "AI-powered Slidev presentation generator using Bedrock AgentCore"
+description = "AI-powered Slidev presentation generator using Bedrock AgentCore and Vertex AI"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "strands-agents>=0.1.0",
+    "strands-agents[gemini]>=0.1.0",
     "strands-agents-tools>=0.1.0",
     "tavily-python>=0.5.0",
     "boto3>=1.35.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "AI-powered Slidev presentation generator using Bedrock AgentCore 
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "strands-agents[gemini]>=0.1.0",
+    "strands-agents[gemini]>=1.27.0",
     "strands-agents-tools>=0.1.0",
     "tavily-python>=0.5.0",
     "boto3>=1.35.0",

--- a/src/slidev_agent/agent.py
+++ b/src/slidev_agent/agent.py
@@ -11,6 +11,30 @@ from .prompts import SYSTEM_PROMPT
 from .tools import web_extract, web_search, write_slidev_markdown
 
 
+def create_model(provider: str | None = None):
+    """
+    Create a model instance based on the provider.
+
+    Args:
+        provider: Model provider ('bedrock' or 'vertexai').
+                  Defaults to env MODEL_PROVIDER or 'bedrock'.
+
+    Returns:
+        Configured model instance.
+    """
+    provider = provider or os.getenv("MODEL_PROVIDER", "bedrock")
+
+    if provider == "vertexai":
+        from strands.models.gemini import GeminiModel
+
+        model_id = os.getenv("GEMINI_MODEL_ID", "gemini-3.1-pro")
+        return GeminiModel(model_id=model_id)
+    else:
+        model_id = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-6-v1")
+        region = os.getenv("AWS_REGION", "us-east-1")
+        return BedrockModel(model_id=model_id, region_name=region)
+
+
 @dataclass
 class SlidevAgentConfig:
     """Configuration for Slidev Agent."""
@@ -26,26 +50,20 @@ class SlidevAgentConfig:
 def create_slidev_agent(
     model_id: str | None = None,
     region: str | None = None,
+    provider: str | None = None,
 ) -> Agent:
     """
     Create a Slidev Agent instance.
 
     Args:
-        model_id: Bedrock model ID to use. Defaults to env BEDROCK_MODEL_ID or Claude Sonnet.
-        region: AWS region for Bedrock. Defaults to env AWS_REGION or us-east-1.
+        model_id: Bedrock model ID (kept for backward compatibility).
+        region: AWS region (kept for backward compatibility).
+        provider: Model provider ('bedrock' or 'vertexai').
 
     Returns:
         Configured Strands Agent for Slidev generation.
     """
-    model_id = model_id or os.getenv(
-        "BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-6-v1:0"
-    )
-    region = region or os.getenv("AWS_REGION", "us-east-1")
-
-    model = BedrockModel(
-        model_id=model_id,
-        region_name=region,
-    )
+    model = create_model(provider)
 
     agent = Agent(
         model=model,

--- a/src/slidev_agent/agent.py
+++ b/src/slidev_agent/agent.py
@@ -27,7 +27,7 @@ def create_model(provider: str | None = None):
     if provider == "vertexai":
         from strands.models.gemini import GeminiModel
 
-        model_id = os.getenv("GEMINI_MODEL_ID", "gemini-3.1-pro")
+        model_id = os.getenv("GEMINI_MODEL_ID", "gemini-3.1-pro-preview")
         return GeminiModel(model_id=model_id)
     else:
         model_id = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-6-v1")

--- a/src/slidev_agent/runtime.py
+++ b/src/slidev_agent/runtime.py
@@ -5,23 +5,15 @@ import os
 from typing import Any
 
 from strands import Agent
-from strands.models import BedrockModel
 
+from .agent import create_model
 from .prompts import SYSTEM_PROMPT
 from .tools import web_extract, web_search, write_slidev_markdown
 
 
 def create_agent() -> Agent:
     """Create the Slidev agent for AgentCore Runtime."""
-    model_id = os.getenv(
-        "BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-6-v1:0"
-    )
-    region = os.getenv("AWS_REGION", "us-east-1")
-
-    model = BedrockModel(
-        model_id=model_id,
-        region_name=region,
-    )
+    model = create_model()
 
     agent = Agent(
         model=model,

--- a/uv.lock
+++ b/uv.lock
@@ -1487,7 +1487,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
-    { name = "strands-agents", extras = ["gemini"], specifier = ">=0.1.0" },
+    { name = "strands-agents", extras = ["gemini"], specifier = ">=1.27.0" },
     { name = "strands-agents-tools", specifier = ">=0.1.0" },
     { name = "tavily-python", specifier = ">=0.5.0" },
 ]
@@ -1538,7 +1538,7 @@ wheels = [
 
 [[package]]
 name = "strands-agents"
-version = "1.24.0"
+version = "1.27.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -1553,9 +1553,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/64/3e4178c512147e7566583544923bb42d84d15f31c22904d79dc94bdaf1d0/strands_agents-1.24.0.tar.gz", hash = "sha256:a3755fcc0befdd99c1b5a5d8a8c98590490f0bb7ab65092dcf9397f7551331de", size = 673930 }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/54/bf0910a1c40feacaedcf5d30840be990eabd09eff5375fa40525ba530c8d/strands_agents-1.27.0.tar.gz", hash = "sha256:84d0b670e534d7c281104a22035c10de8d43e9ad8ee589bde16f54a8387b2c56", size = 712878 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/f0/81e96a356cf937ae697e28514b9e850d390802341df4ae6498ab737de744/strands_agents-1.24.0-py3-none-any.whl", hash = "sha256:035e0b8aa404bfaada4459a841aeed66f2a165fbb66f4d448dd6eceb4c14be44", size = 337217 },
+    { url = "https://files.pythonhosted.org/packages/6a/ca/d5c269f83929bdc753dce3c6091a1671e50268769b0ace009264424bf165/strands_agents-1.27.0-py3-none-any.whl", hash = "sha256:d9012515a7b4f324a600cacc539e837a51b3f7fe21da7efe1764186ade3be498", size = 351988 },
 ]
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -375,6 +375,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277 },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -454,6 +463,47 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451 },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507 },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409 },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499 },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.64.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/14/344b450d4387845fc5c8b7f168ffbe734b831b729ece3333fc0fe8556f04/google_genai-1.64.0.tar.gz", hash = "sha256:8db94ab031f745d08c45c69674d1892f7447c74ed21542abe599f7888e28b924", size = 496434 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/56/765eca90c781fedbe2a7e7dc873ef6045048e28ba5f2d4a5bcb13e13062b/google_genai-1.64.0-py3-none-any.whl", hash = "sha256:78a4d2deeb33b15ad78eaa419f6f431755e7f0e03771254f8000d70f717e940b", size = 728836 },
 ]
 
 [[package]]
@@ -941,6 +991,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371 },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259 },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1305,6 +1376,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
+]
+
+[[package]]
 name = "ruff"
 version = "0.14.14"
 source = { registry = "https://pypi.org/simple" }
@@ -1382,7 +1465,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "rich" },
-    { name = "strands-agents" },
+    { name = "strands-agents", extra = ["gemini"] },
     { name = "strands-agents-tools" },
     { name = "tavily-python" },
 ]
@@ -1404,11 +1487,20 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4.0" },
-    { name = "strands-agents", specifier = ">=0.1.0" },
+    { name = "strands-agents", extras = ["gemini"], specifier = ">=0.1.0" },
     { name = "strands-agents-tools", specifier = ">=0.1.0" },
     { name = "tavily-python", specifier = ">=0.5.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
 
 [[package]]
 name = "soupsieve"
@@ -1464,6 +1556,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/64/3e4178c512147e7566583544923bb42d84d15f31c22904d79dc94bdaf1d0/strands_agents-1.24.0.tar.gz", hash = "sha256:a3755fcc0befdd99c1b5a5d8a8c98590490f0bb7ab65092dcf9397f7551331de", size = 673930 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/f0/81e96a356cf937ae697e28514b9e850d390802341df4ae6498ab737de744/strands_agents-1.24.0-py3-none-any.whl", hash = "sha256:035e0b8aa404bfaada4459a841aeed66f2a165fbb66f4d448dd6eceb4c14be44", size = 337217 },
+]
+
+[package.optional-dependencies]
+gemini = [
+    { name = "google-genai" },
 ]
 
 [[package]]
@@ -1649,6 +1746,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/62/a7c072fbfefb2980a00f99ca994279cb9ecf310cb2e6b2a4d2a28fe192b3/wcwidth-0.5.3.tar.gz", hash = "sha256:53123b7af053c74e9fe2e92ac810301f6139e64379031f7124574212fb3b4091", size = 157587 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/c1/d73f12f8cdb1891334a2ccf7389eed244d3941e74d80dd220badb937f3fb/wcwidth-0.5.3-py3-none-any.whl", hash = "sha256:d584eff31cd4753e1e5ff6c12e1edfdb324c995713f75d26c29807bb84bf649e", size = 92981 },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440 },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098 },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329 },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111 },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054 },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496 },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829 },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217 },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195 },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- `create_model()` 関数を追加し、`MODEL_PROVIDER` 環境変数で Bedrock / Vertex AI Gemini を切り替え可能に
- `runtime.py` のモデル生成ロジックを `create_model()` に統一し重複コードを削除
- `.env.example` に Vertex AI 関連の環境変数テンプレートを追加

Closes #2

## Test plan
- [x] `uv lock` が成功すること
- [x] `uv run --extra dev pytest` で既存テスト10件がすべてパス
- [ ] `MODEL_PROVIDER=bedrock` で従来通り動作すること
- [ ] `MODEL_PROVIDER=vertexai` で Gemini 3.1 Pro が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)